### PR TITLE
FIX End of communication 

### DIFF
--- a/iec870ree_moxa/moxa.py
+++ b/iec870ree_moxa/moxa.py
@@ -48,8 +48,12 @@ class Moxa(PhysicalLayer):
             raise ConnectionError(e)
 
     def initialize_modem(self):
+        self.writeat("+++", no_r=True)
+        time.sleep(3)
         self.writeat("ATZ")
         time.sleep(2)  # at least two seconds after ATZ (reset) command
+        self.writeat("ATH0")
+        time.sleep(10)
         self.writeat("AT+CBST=7,0,1")
         time.sleep(3)
         self.writeat("ATD" + str(self.phone_number))
@@ -82,7 +86,7 @@ class Moxa(PhysicalLayer):
 
         try:
             if self.data_mode:
-                self.writeat("+++")
+                self.writeat("+++", no_r=True)
                 time.sleep(3)
             self.writeat("ATH0")
             time.sleep(3)
@@ -105,9 +109,12 @@ class Moxa(PhysicalLayer):
             raise ModemException("modem not in datamode")
         return self.queue.get(True, timeout)
 
-    def writeat(self, value):
+    def writeat(self, value, no_r=False):
         logger.info("sending command " + value)
-        self.write((value + "\r").encode("ascii"))
+        sufix = "\r"
+        if no_r:
+            sufix = ''
+        self.write((value + sufix).encode("ascii"))
 
     def write(self, value):
         if not self.connected:


### PR DESCRIPTION
There was two problems on communication closing:

* '+++' must be without \r char
* `recv` is a blocking command. Add a timeout to allow clean thread exit